### PR TITLE
RSDK-2013 CXX14 -> CXX17

### DIFF
--- a/viam-orb-slam3/CMakeLists.txt
+++ b/viam-orb-slam3/CMakeLists.txt
@@ -23,14 +23,14 @@ message("PROJECT SOURCE DIR: " ${PROJECT_SOURCE_DIR})
 message("API SOURCE DIR: " ${API_SOURCE_DIR})
 message("GRPC SOURCE DIR: " ${SRCDIR})
 
-# Check C++14 or C++0x support
+# Check C++17 or C++0x support
 include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag("-std=c++14" COMPILER_SUPPORTS_CXX14)
+check_cxx_compiler_flag("-std=c++17" COMPILER_SUPPORTS_CXX17)
 check_cxx_compiler_flag("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX14)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-  add_definitions(-DCOMPILEDWITHC14)
-  message(STATUS "Using flag -std=c++14.")
+if(COMPILER_SUPPORTS_CXX17)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+  add_definitions(-DCOMPILEDWITHC17)
+  message(STATUS "Using flag -std=c++17.")
 elseif(COMPILER_SUPPORTS_CXX0X)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
   add_definitions(-DCOMPILEDWITHC0X)
@@ -38,7 +38,7 @@ elseif(COMPILER_SUPPORTS_CXX0X)
 else()
   message(
     FATAL_ERROR
-      "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support. Please use a different C++ compiler."
+      "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support. Please use a different C++ compiler."
   )
 endif()
 

--- a/viam-orb-slam3/CMakeLists.txt
+++ b/viam-orb-slam3/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 project(ORB_SLAM_CUSTOM)
 
-add_definitions(-DABSL_LEGACY_THREAD_ANNOTATIONS)
-
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()


### PR DESCRIPTION
This updates our CMakeLists to use cxx17 to support our brew package.

Without this change, building the brew package produces: 
```
home/linuxbrew/.linuxbrew/Cellar/abseil/20230125.1/include/absl/strings/string_view.h:52:21: note: 'std::string_view' is only available from C++17 onwards
   52 | using string_view = std::string_view;
```
and fails to compile. In theory, absl should be using its own string_view (absl::string_view), however I suspect that one of our dependencies has defined ABSL_USES_STD_STRING_VIEW. This causes it to require cxx17 and fail to compile.

With this PR, the brew package is able to build successfully.

Fixing this does not require increasing the cxx version in ORB_SLAM3 however we may want to do that as well.

I also want to correct a mistake I made two days ago: I had said that 
```
add_definitions(-DABSL_LEGACY_THREAD_ANNOTATIONS)
```
was required to get this to compile. However, I was mistaken. After I added this annotation, I re-ran the standard `make setup && make build` and I suspect that I contaminated my docker container. A fresh docker container does not require this flag to build.