### PR TITLE
[RSDK-1885] Assert assumptions about float, char, and int size

### DIFF
--- a/viam-orb-slam3/orbslam_server_v1_main.cc
+++ b/viam-orb-slam3/orbslam_server_v1_main.cc
@@ -32,6 +32,9 @@ int main(int argc, char **argv) {
     sigaction(SIGTERM, &sigHandler, NULL);
     sigaction(SIGINT, &sigHandler, NULL);
 
+    static_assert((sizeof(float) == 4) && (CHAR_BIT == 8) && (sizeof(int) == 4),
+                  "32 bit float & 8 bit char & 32 bit int is assumed");
+
     viam::SLAMServiceImpl slamService;
     slamService.SetSlam(nullptr);
 


### PR DESCRIPTION
Only added an assert about float, char, and int size to match what's [in viam-cartographer](https://github.com/viamrobotics/viam-cartographer/blob/fc157f534dba6fd0c72dc953c8917503a453521b/viam-cartographer/src/main.cc#L31-L32).

I looked into asserting that we're running on a little-endian system, but it's a little complicated, so I left it out for now. This was a good resource: https://vietlq.github.io/2018/06/17/endianness-detection-the-hard-way/