### PR TITLE
[RSDK-1786] add slack alerts for failed main branch updates

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -31,9 +31,6 @@ jobs:
     timeout-minutes: 45
 
     steps:
-    - name: fail please
-      run: exit 1
-      
     - name: Check out code in viam-orb-slam3 directory
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -31,6 +31,9 @@ jobs:
     timeout-minutes: 45
 
     steps:
+    - name: fail please
+      run: exit 1
+      
     - name: Check out code in viam-orb-slam3 directory
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,4 +38,3 @@ jobs:
             slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
             channel: '#team-slam-dev'
             name: 'Workflow Status'
-            

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   appimage:
-    uses: viamrobotics/viam-orb-slam3/.github/workflows/appimage.yml@alerts
+    uses: viamrobotics/viam-orb-slam3/.github/workflows/appimage.yml@main
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
@@ -38,3 +38,4 @@ jobs:
             slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
             channel: '#team-slam-dev'
             name: 'Workflow Status'
+            

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
   slack-workflow-status:
-      # if: ${{ failure() }}
+      if: ${{ failure() }}
       name: Post Workflow Status To Slack
       needs:
         - appimage
@@ -36,5 +36,5 @@ jobs:
           with:
             repo_token: ${{secrets.GITHUB_TOKEN}}
             slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
-            channel: '#team-slam'
+            channel: '#team-slam-dev'
             name: 'Workflow Status'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   appimage:
-    uses: viamrobotics/viam-orb-slam3/.github/workflows/appimage.yml@main
+    uses: viamrobotics/viam-orb-slam3/.github/workflows/appimage.yml@alerts
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
   slack-workflow-status:
-      # if: ${{ failure() }}
+      if: ${{ failure() }}
       name: Post Workflow Status To Slack
       # needs:
       #   - appimage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,3 +21,20 @@ jobs:
     uses: viamrobotics/viam-orb-slam3/.github/workflows/appimage.yml@main
     secrets:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+
+  slack-workflow-status:
+      # if: ${{ failure() }}
+      name: Post Workflow Status To Slack
+      needs:
+        - appimage
+      runs-on: ubuntu-latest
+      permissions:
+        actions: 'read'
+      steps:
+        - name: Slack Workflow Notification
+          uses: Gamesight/slack-workflow-status@master
+          with:
+            repo_token: ${{secrets.GITHUB_TOKEN}}
+            slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
+            channel: '#team-devops'
+            name: 'Workflow Status'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,8 @@ jobs:
   slack-workflow-status:
       if: ${{ failure() }}
       name: Post Workflow Status To Slack
-      # needs:
-      #   - appimage
+      needs:
+        - appimage
       runs-on: ubuntu-latest
       permissions:
         actions: 'read'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,5 +36,5 @@ jobs:
           with:
             repo_token: ${{secrets.GITHUB_TOKEN}}
             slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
-            channel: '#team-devops'
+            channel: '#team-slam'
             name: 'Workflow Status'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,10 @@ jobs:
       GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
 
   slack-workflow-status:
-      if: ${{ failure() }}
+      # if: ${{ failure() }}
       name: Post Workflow Status To Slack
-      needs:
-        - appimage
+      # needs:
+      #   - appimage
       runs-on: ubuntu-latest
       permissions:
         actions: 'read'
@@ -36,5 +36,5 @@ jobs:
           with:
             repo_token: ${{secrets.GITHUB_TOKEN}}
             slack_webhook_url: ${{secrets.SLACK_WEBHOOK_URL}}
-            channel: '#team-slam-dev'
+            channel: '#team-slam-github-notifs'
             name: 'Workflow Status'


### PR DESCRIPTION
uses a [slack webhook](https://viaminc.slack.com/apps/A0F7XDUAZ-incoming-webhooks?tab=settings&next_id=0) to send alerts to #team-slam-dev whenever a main branch update fails. 

failing action: https://github.com/viamrobotics/viam-orb-slam3/actions/runs/4407884564
<img width="686" alt="Screenshot 2023-03-13 at 1 39 14 PM" src="https://user-images.githubusercontent.com/92045055/224798262-2a275184-86ee-4f04-88c4-efabdd0c088a.png">


ticket: https://viam.atlassian.net/browse/RSDK-1786

additional PRs for after this one is merged(effectively the same)
[slam repo](https://github.com/viamrobotics/slam/pull/178)
[cartographer repo](https://github.com/viamrobotics/viam-cartographer/pull/13)