### PR TITLE
RSDK-2028 Set up orbslam integration tests automation in CI

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ 'main' ]
+    branches: [ 'zp/2028-integration-tests-ci' ]
     types: [ 'opened', 'reopened', 'synchronize' ]
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/viam-orb-slam3
@@ -16,4 +16,4 @@ on:
 
 jobs:
   test:
-    uses: viamrobotics/viam-orb-slam3/.github/workflows/test.yml@main
+    uses: viamrobotics/viam-orb-slam3/.github/workflows/test.yml@zp/2028-integration-tests-ci

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ 'zp/2028-integration-tests-ci' ]
+    branches: [ 'main' ]
     types: [ 'opened', 'reopened', 'synchronize' ]
 
 # To test workflow updates you need to work in a branch directly on viamrobotics/viam-orb-slam3
@@ -16,4 +16,4 @@ on:
 
 jobs:
   test:
-    uses: viamrobotics/viam-orb-slam3/.github/workflows/test.yml@zp/2028-integration-tests-ci
+    uses: viamrobotics/viam-orb-slam3/.github/workflows/test.yml@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,3 +92,8 @@ jobs:
       if: matrix.platform == 'linux/amd64'
       run: |
         sudo -u testbot bash -lc 'cd rdk/services/slam/builtin && sudo go test -v -run TestOrbslamIntegration'
+
+    - name: Run viam-orb-slam3 integration tests
+      if: matrix.platform == 'linux/amd64'
+      run: |
+        sudo -u testbot bash -lc 'cd viam-orb-slam3 && sudo go test -v -run TestOrbslamIntegration'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Run rdk orbslam integration tests
       if: matrix.platform == 'linux/amd64'
       run: |
-        sudo -u testbot bash -lc 'cd rdk/services/slam/builtin && sudo go test -v -run TestOrbslamIntegration'
+        sudo -u testbot bash -lc 'cd rdk/services/slam/builtin && sudo go test -v -race -run TestOrbslamIntegration'
 
     - name: Run viam-orb-slam3 integration tests
       if: matrix.platform == 'linux/amd64'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,4 +96,4 @@ jobs:
     - name: Run viam-orb-slam3 integration tests
       if: matrix.platform == 'linux/amd64'
       run: |
-        sudo -u testbot bash -lc 'cd viam-orb-slam3 && sudo go test -v -run TestOrbslamIntegration'
+        sudo -u testbot bash -lc 'cd viam-orb-slam3 && sudo go test -v -race -run TestOrbslamIntegration'


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-2028

This mirrors the cartographer integration test changes (https://github.com/viamrobotics/viam-cartographer/pull/20). 

Just like cartographer, this keeps the RDK integration tests. Deleting those could be dangerous until we have deleted the code in the RDK.

This PR adds the integration tests and ensures tests this CI: https://github.com/viamrobotics/viam-orb-slam3/pull/23