### PR TITLE
RSDK-2029 - Remove/replace rdk integration tests with local tests

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -56,17 +56,10 @@ jobs:
       run: |
         sudo cp viam-orb-slam3/viam-orb-slam3/bin/orb_grpc_server /usr/local/bin/orb_grpc_server
 
-    - name: Check out code in rdk directory
-      if: matrix.platform == 'linux/amd64'
-      uses: actions/checkout@v3
-      with:
-        repository: viamrobotics/rdk
-        path: rdk
-
-    - name: Run rdk slam integration tests
+    - name: Run viam-orb-slam3 integration tests
       if: matrix.platform == 'linux/amd64'
       run: |
-        sudo -u testbot bash -lc 'cd rdk/services/slam/builtin && sudo go test -v -run TestOrbslamIntegration'
+        sudo -u testbot bash -lc 'cd viam-orb-slam3 && sudo go test -v -race -run TestOrbslamIntegration'
 
     - name: Build appimage
       run: sudo -u testbot bash -lc 'cd viam-orb-slam3 && make BUILD_CHANNEL="latest" appimage'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,19 +80,6 @@ jobs:
       run: |
         sudo cp viam-orb-slam3/viam-orb-slam3/bin/orb_grpc_server /usr/local/bin/orb_grpc_server
 
-    - name: Check out code in rdk directory
-      if: matrix.platform == 'linux/amd64'
-      uses: actions/checkout@v3
-      # Pulls main/HEAD from rdk to ensure no accidental regressions
-      with:
-        repository: viamrobotics/rdk 
-        path: rdk
-
-    - name: Run rdk orbslam integration tests
-      if: matrix.platform == 'linux/amd64'
-      run: |
-        sudo -u testbot bash -lc 'cd rdk/services/slam/builtin && sudo go test -v -race -run TestOrbslamIntegration'
-
     - name: Run viam-orb-slam3 integration tests
       if: matrix.platform == 'linux/amd64'
       run: |

--- a/orbslam_yaml_test.go
+++ b/orbslam_yaml_test.go
@@ -15,13 +15,14 @@ import (
 	"github.com/edaniels/golog"
 	"github.com/pkg/errors"
 	"go.viam.com/rdk/rimage/transform"
-	"go.viam.com/rdk/services/slam/builtin"
 	slamConfig "go.viam.com/slam/config"
 	"go.viam.com/slam/dataprocess"
 	slamTesthelper "go.viam.com/slam/testhelper"
 	"go.viam.com/test"
 	"go.viam.com/utils"
 	"gopkg.in/yaml.v2"
+
+	viamorbslam3 "github.com/viamrobotics/viam-orb-slam3"
 )
 
 const yamlFilePrefixBytes = "%YAML:1.0\n"
@@ -134,7 +135,7 @@ func TestOrbslamYAMLNew(t *testing.T) {
 		test.That(t, yamlDataAll[:len(yamlFilePrefixBytes)], test.ShouldResemble, []byte(yamlFilePrefixBytes))
 
 		yamlData := bytes.Replace(yamlDataAll, []byte(yamlFilePrefixBytes), []byte(""), 1)
-		orbslam := builtin.ORBsettings{}
+		orbslam := viamorbslam3.ORBsettings{}
 		err = yaml.Unmarshal(yamlData, &orbslam)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, orbslam.Width, test.ShouldEqual, 1280)
@@ -170,7 +171,7 @@ func TestOrbslamYAMLNew(t *testing.T) {
 		yamlDataAll, err := os.ReadFile(yamlFilePathGood)
 		test.That(t, err, test.ShouldBeNil)
 		yamlData := bytes.Replace(yamlDataAll, []byte(yamlFilePrefixBytes), []byte(""), 1)
-		orbslam := builtin.ORBsettings{}
+		orbslam := viamorbslam3.ORBsettings{}
 		err = yaml.Unmarshal(yamlData, &orbslam)
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, orbslam.LoadMapLoc, test.ShouldEqual, "\""+fakeMap+"\"")
@@ -197,7 +198,7 @@ func TestOrbslamYAMLNew(t *testing.T) {
 		test.That(t, yamlDataAll[:len(yamlFilePrefixBytes)], test.ShouldResemble, []byte(yamlFilePrefixBytes))
 
 		yamlData := bytes.Replace(yamlDataAll, []byte(yamlFilePrefixBytes), []byte(""), 1)
-		orbslam := builtin.ORBsettings{}
+		orbslam := viamorbslam3.ORBsettings{}
 		err = yaml.Unmarshal(yamlData, &orbslam)
 		test.That(t, err, test.ShouldBeNil)
 

--- a/viam-orb-slam3/orbslam_server_v1.h
+++ b/viam-orb-slam3/orbslam_server_v1.h
@@ -84,7 +84,7 @@ class SLAMServiceImpl final : public SLAMService::Service {
     std::atomic<bool> use_live_data{false};
     bool delete_processed_data = false;
     // The size of the buffer has to be the same as
-    // dataBufferSize in RDK's builtin_test.go
+    // dataBufferSize in viam-orb-slam3_test.go
     const int data_buffer_size = 4;
     int first_processed_file_index = -1;
     bool local_viewer_flag = false;


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-2029

Done:
* Removed/replaced any RDK builtin based integration tests with viam-orb-slam3 equivalent integration tests
* Removed any remaining mention of RDK builtin with locally referenced equivalent code

NOTE: 
* Must be merged before merging https://github.com/viamrobotics/rdk/pull/2271